### PR TITLE
Consume jobs per queue

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -10,10 +10,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/Henrod/task-queue/taskqueue"
-	"github.com/google/uuid"
 )
 
 type Payload struct {

--- a/taskqueue/options.go
+++ b/taskqueue/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	WorkerID         string
 	MaxRetries       int
 	OperationTimeout time.Duration
+	QueueKey         string
 }
 
 func (o *Options) setDefaults() {
@@ -29,5 +30,9 @@ func (o *Options) setDefaults() {
 
 	if o.OperationTimeout == 0 {
 		o.OperationTimeout = 5 * time.Second
+	}
+
+	if o.QueueKey == "" {
+		o.QueueKey = "taskqueue"
 	}
 }

--- a/taskqueue/options.go
+++ b/taskqueue/options.go
@@ -4,12 +4,12 @@ import "time"
 
 // TODO: receive user's logger as optional
 type Options struct {
+	QueueKey         string
 	Namespace        string
-	Address          string
+	StorageAddress   string
 	WorkerID         string
 	MaxRetries       int
 	OperationTimeout time.Duration
-	QueueKey         string
 }
 
 func (o *Options) setDefaults() {
@@ -17,8 +17,8 @@ func (o *Options) setDefaults() {
 		o.Namespace = "default"
 	}
 
-	if o.Address == "" {
-		o.Address = "localhost:6379"
+	if o.StorageAddress == "" {
+		o.StorageAddress = "localhost:6379"
 	}
 
 	if o.WorkerID == "" {

--- a/taskqueue/options.go
+++ b/taskqueue/options.go
@@ -2,6 +2,7 @@ package taskqueue
 
 import "time"
 
+// TODO: receive user's logger as optional
 type Options struct {
 	Namespace        string
 	Address          string

--- a/taskqueue/task_queue.go
+++ b/taskqueue/task_queue.go
@@ -45,8 +45,8 @@ func NewTaskQueue(ctx context.Context, options *Options) (*TaskQueue, error) {
 
 	taskQueue := &TaskQueue{
 		redis:             redisClient,
-		taskQueueKey:      fmt.Sprintf("taskqueue:%s:tasks", options.Namespace),
-		inProgressTaskKey: fmt.Sprintf("taskqueue:%s:workers:%s:tasks", options.Namespace, options.WorkerID),
+		taskQueueKey:      fmt.Sprintf("taskqueue:%s:tasks:%s", options.Namespace, options.QueueKey),
+		inProgressTaskKey: fmt.Sprintf("taskqueue:%s:workers:%s:tasks:%s", options.Namespace, options.WorkerID, options.QueueKey),
 		consumeScriptSha:  consumeScriptSHA,
 		maxRetries:        options.MaxRetries,
 		operationTimeout:  options.OperationTimeout,

--- a/taskqueue/task_queue.go
+++ b/taskqueue/task_queue.go
@@ -32,7 +32,7 @@ const consumeScriptPath = "./taskqueue/consume.lua"
 
 func NewTaskQueue(ctx context.Context, options *Options) (*TaskQueue, error) {
 	options.setDefaults()
-	redisClient := redis.NewClient(&redis.Options{Addr: options.Address})
+	redisClient := redis.NewClient(&redis.Options{Addr: options.StorageAddress})
 
 	consumeScriptBytes, err := os.ReadFile(consumeScriptPath)
 	if err != nil {


### PR DESCRIPTION
# Description

Use queueKey to specify a TaskQueue instance to consume a single queue. 